### PR TITLE
Updated Rules to return valid JSON Booleans

### DIFF
--- a/docs/courses/chatbot-rulesets/08_adding_another_ruleset_for_output.md
+++ b/docs/courses/chatbot-rulesets/08_adding_another_ruleset_for_output.md
@@ -89,7 +89,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that is your response to the user."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 
@@ -239,7 +239,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that is your response to the user."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/09_formatting_chat_output.md
+++ b/docs/courses/chatbot-rulesets/09_formatting_chat_output.md
@@ -133,7 +133,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that is your response to the user."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/10_markdown_madness.md
+++ b/docs/courses/chatbot-rulesets/10_markdown_madness.md
@@ -145,7 +145,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format. Include line returns when necessary."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/11_gleaming_the_chat.md
+++ b/docs/courses/chatbot-rulesets/11_gleaming_the_chat.md
@@ -108,7 +108,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format. Include line returns when necessary."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/12_multiple_personas.md
+++ b/docs/courses/chatbot-rulesets/12_multiple_personas.md
@@ -156,7 +156,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format. Include line returns when necessary."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/13_adding_personality_colors.md
+++ b/docs/courses/chatbot-rulesets/13_adding_personality_colors.md
@@ -216,7 +216,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format. Include line returns when necessary."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/14_making_it_quick.md
+++ b/docs/courses/chatbot-rulesets/14_making_it_quick.md
@@ -119,7 +119,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format. Include line returns when necessary."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/08_app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/08_app.py
@@ -23,7 +23,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that is your response to the user."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/09_app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/09_app.py
@@ -27,7 +27,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that is your response to the user."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/10_app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/10_app.py
@@ -28,7 +28,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/11_app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/11_app.py
@@ -30,7 +30,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/12_app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/12_app.py
@@ -54,7 +54,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/13_app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/13_app.py
@@ -60,7 +60,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/14_app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/14_app.py
@@ -61,7 +61,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/docs/courses/chatbot-rulesets/assets/examples/app.py
+++ b/docs/courses/chatbot-rulesets/assets/examples/app.py
@@ -92,7 +92,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/08_app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/08_app.py
@@ -23,7 +23,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that is your response to the user."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/09_app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/09_app.py
@@ -27,7 +27,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that is your response to the user."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/10_app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/10_app.py
@@ -28,7 +28,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/11_app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/11_app.py
@@ -30,7 +30,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/12_app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/12_app.py
@@ -54,7 +54,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: response, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/13_app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/13_app.py
@@ -60,7 +60,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/14_app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/14_app.py
@@ -61,7 +61,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 

--- a/site/courses/chatbot-rulesets/assets/examples/app.py
+++ b/site/courses/chatbot-rulesets/assets/examples/app.py
@@ -92,7 +92,7 @@ json_ruleset = Ruleset(
     rules=[
         Rule("Respond in plain text only with JSON objects that have the following keys: name, response, favorite_color, continue_chatting."),
         Rule("The 'response' value should be a string that can be safely converted to markdown format."),
-        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to False, otherwise it is True"),
+        Rule("If it sounds like the person is done chatting, set 'continue_chatting' to false, otherwise it is true"),
     ]
 )
 


### PR DESCRIPTION
Changed JSON Ruleset strings to not include a capitalized True and False. The agent was returning it's responses with Capitalized True and False which was causing issues with JSON Decoding. 