### PR TITLE
fix: ValueError Tool name can only contain letters and numbers.

### DIFF
--- a/docs/courses/create-image-pipeline/02_concepts.md
+++ b/docs/courses/create-image-pipeline/02_concepts.md
@@ -70,23 +70,23 @@ In this course, we will be focusing mostly on **Prompt Tasks**, **Image Generati
 ```python
 # Example PromptTask to create a Image Generation Prompt
 #
-image_prompt_task = PromptTask(
+imageprompttask = PromptTask(
     "Create a prompt for an image generation engine that will make a watercolor painting of: {{ topic }}",
     context = {                        
         "topic": "butterfly" 
     },
-    id="image_prompt_task"   # task id can be referenced by other tasks
+    id="imageprompttask"   # task id can be referenced by other tasks
 )
 
 # This Image Generation task works with the output of the parent task.
 #
-image_generation_task = PromptImageGenerationTask(
+imagegenerationtask = PromptImageGenerationTask(
     "{{ parent_output }}", # The output of the parent task
     image_generation_driver=OpenAiImageGenerationDriver(
         model="dall-e-3", api_type="open_ai", image_size="1024x1024"
     ),
     output_dir="./images",
-    id="image_generation_task"
+    id="imagegenerationtask"
 )
 ```
 

--- a/docs/courses/create-image-pipeline/03_first_pipeline.md
+++ b/docs/courses/create-image-pipeline/03_first_pipeline.md
@@ -80,7 +80,7 @@ After the `pipeline` line, add:
 # ...
 
 # Create tasks
-create_prompt_task = PromptTask(
+createprompttask = PromptTask(
     """
     Create a prompt for an Image Generation pipeline for the following topic: 
     {{ args[0] }}
@@ -157,7 +157,7 @@ After the PromptTask line, add:
 # ...
 
 # Add tasks to pipeline
-pipeline.add_task(create_prompt_task)
+pipeline.add_task(createprompttask)
 ```
 
 At this point, your pipeline flow graph looks like:
@@ -217,17 +217,17 @@ The next two tasks we create will be "fake" ones - meaning they are simply there
 
 The fake image generation task will be another `PromptTask` that will tell the LLM to "pretend" to generate an image. It will take the `output` from the parent task, and feed it to this task using the Jinja2 `{{ }}` syntax. If you've taken the [Compare Movies - Workflows](../compare-movies-workflow/index.md) course you've seen this before.
 
-Create the task in your `app.py` file by inserting the following code after the `create_prompt_task` but before the section of the code where you add the tasks to the pipeline.
+Create the task in your `app.py` file by inserting the following code after the `createprompttask` but before the section of the code where you add the tasks to the pipeline.
 
 ```python hl_lines="8-16"
 # ...
 
 # Create tasks
-create_prompt_task = PromptTask(
+createprompttask = PromptTask(
     # ...
 )
 
-generate_image_task = PromptTask(
+generateimagetask = PromptTask(
     """
     Pretend to create an image using this prompt, 
     and return the filename of the generated image: 
@@ -252,12 +252,12 @@ Find the `add_task` line in your code. We're going to modify it to add _multiple
 Modify this line:
 
 ```python
-pipeline.add_task(create_prompt_task)
+pipeline.add_task(createprompttask)
 ```
 
 Turn it to:
 ```python
-pipeline.add_tasks(create_prompt_task, generate_image_task)
+pipeline.add_tasks(createprompttask, generateimagetask)
 
 ```
 
@@ -278,7 +278,7 @@ load_dotenv()  # Load your environment
 pipeline = Pipeline()
 
 # Create tasks
-create_prompt_task = PromptTask(
+createprompttask = PromptTask(
     """
     Create a prompt for an Image Generation pipeline for the following topic: 
     {{ args[0] }}
@@ -288,7 +288,7 @@ create_prompt_task = PromptTask(
     id="Create Prompt Task",
 )
 
-generate_image_task = PromptTask(
+generateimagetask = PromptTask(
     """
     Pretend to create an image using this prompt, 
     and return the filename of the generated image: 
@@ -298,7 +298,7 @@ generate_image_task = PromptTask(
 )
 
 # Add tasks to pipeline
-pipeline.add_tasks(create_prompt_task, generate_image_task)
+pipeline.add_tasks(createprompttask, generateimagetask)
 
 # Run the pipeline
 pipeline.run("a cow")
@@ -395,21 +395,21 @@ In this task, we'll "display" the image to the user. Later in the course, we'll 
 
 The fake view image task will also be a PromptTask that tells the LLM to pretend to display the image to the viewer. Just like before, it will take the `output` from the parent task, and feed it to this one.
 
-Update the `app.py` file by inserting a new `display_image_task` after the previous `generate_image_task`.
+Update the `app.py` file by inserting a new `displayimagetask` after the previous `generateimagetask`.
 
 ```python hl_lines="12-18"
 # ...
 
 # Create tasks
-create_prompt_task = PromptTask(
+createprompttask = PromptTask(
     # ...
 )
 
-generate_image_task = PromptTask(
+generateimagetask = PromptTask(
     # ...
 )
 
-display_image_task = PromptTask(
+displayimagetask = PromptTask(
     """
     Pretend to display the image to the user. 
     {{ parent_output }}.
@@ -431,7 +431,7 @@ Add the new task to the line where we `add_tasks` to the pipeline.
 # ...
 
 # Add tasks to the pipeline
-pipeline.add_tasks(create_prompt_task, generate_image_task, display_image_task)
+pipeline.add_tasks(createprompttask, generateimagetask, displayimagetask)
 
 # ...
 ```

--- a/docs/courses/create-image-pipeline/04_creating_images.md
+++ b/docs/courses/create-image-pipeline/04_creating_images.md
@@ -82,12 +82,12 @@ image_driver = OpenAiImageGenerationDriver(
 
 ### Replace the ImageTask
 
-Next, we'll replace our fake image generation task with a _real_ image generation task. Find the section of the code where we're creating the image task with `generate_image_task` and replace it with `PromptImageGenerationTask`.
+Next, we'll replace our fake image generation task with a _real_ image generation task. Find the section of the code where we're creating the image task with `generateimagetask` and replace it with `PromptImageGenerationTask`.
 
 ```python
 # ...
 
-generate_image_task = PromptImageGenerationTask(
+generateimagetask = PromptImageGenerationTask(
     "{{ parent_output }}",
     image_generation_driver=image_driver,
     output_dir="images",
@@ -171,12 +171,12 @@ In order to discover that, we need to know what kind of `Artifact` the task outp
 
 However, if we do this with our code you'll see that the `value` being passed back from the ImageGenerationTask are the _raw bytes of the image_. It's _way_ too big for the LLM, and isn't what we want anyway. 
 
-To demonstrate (and so you don't need to do it yourself), I'm going to replace the `{{ parent_output }}` in the `display_image_task` with `{{ parent.output.value }}` and show the results.
+To demonstrate (and so you don't need to do it yourself), I'm going to replace the `{{ parent_output }}` in the `displayimagetask` with `{{ parent.output.value }}` and show the results.
 
 ```python hl_lines="6"
 # ...
 
-display_image_task = PromptTask(
+displayimagetask = PromptTask(
     """
     Pretend to display the image to the user. 
     {{ parent.output.value }}
@@ -265,12 +265,12 @@ How about that `name` attribute? It says it's the name of the artifact, generate
 
 Navigate back to your `app.py` in Visual Studio Code.
 
-Inside the `display_image_task` section, replace `{{ parent_output }}` with `{{ parent.output.name }}`.
+Inside the `displayimagetask` section, replace `{{ parent_output }}` with `{{ parent.output.name }}`.
 
 ```python title="app.py" hl_lines="6"
 # ...
 
-display_image_task = PromptTask(
+displayimagetask = PromptTask(
     """
     Pretend to display the image to the user. 
     {{ parent.output.name }}
@@ -323,14 +323,14 @@ output_dir = "images"
 # ...
 ```
 
-### Replace in `generate_image_task`
+### Replace in `generateimagetask`
 
-Now go down to the `generate_image_task` and use the `output_dir` variable in the `PromptImageGenerationTask`.
+Now go down to the `generateimagetask` and use the `output_dir` variable in the `PromptImageGenerationTask`.
 
 ```python title="app.py" hl_lines="6"
 # ...
 
-generate_image_task = PromptImageGenerationTask(
+generateimagetask = PromptImageGenerationTask(
     "{{ parent_output }}",
     image_generation_driver=image_driver,
     output_dir=output_dir,
@@ -340,14 +340,14 @@ generate_image_task = PromptImageGenerationTask(
 # ...
 ```
 
-### Create context in `display_image_task`
+### Create context in `displayimagetask`
 
-Finally, back to the `display_image_task`, we'll create a `context`, provide the `output_dir`, and use it in our prompt.
+Finally, back to the `displayimagetask`, we'll create a `context`, provide the `output_dir`, and use it in our prompt.
 
 ```python title="app.py" hl_lines="6 8"
 # ...
 
-display_image_task = PromptTask(
+displayimagetask = PromptTask(
     """
     Pretend to display the image to the user. 
     {{output_dir}}/{{ parent.output.name }}
@@ -390,4 +390,4 @@ Our next task is to replace our fake Display Image with a real one. There are a 
 
 All three of these methods are valid, but in the context of this course, we're going to learn how to use the `CodeExecutionTask` to run a simple Python function within the Pipeline. This will be a great example of how to include generic Python code within Pipelines and Workflows _that does not hit an LLM_.
 
-Let's dive in and learn how to use the `CodeExecutionTask` to [display an image](07_display_image_task.md).
+Let's dive in and learn how to use the `CodeExecutionTask` to [display an image](07_displayimagetask.md).

--- a/docs/courses/create-image-pipeline/07_display_image_task.md
+++ b/docs/courses/create-image-pipeline/07_display_image_task.md
@@ -108,7 +108,7 @@ We'll use this combination of techniques to send the `output_dir` and the name o
 
 ## Add Display Image Task
 
-First, let's change the `display_image_task` from a `PromptTask` to a `CodeExecutionTask`. 
+First, let's change the `displayimagetask` from a `PromptTask` to a `CodeExecutionTask`. 
 
 ### Import `CodeExecutionTask`
 
@@ -125,14 +125,14 @@ from griptape.tasks import (
 ```
 
 
-### Modify display_image_task
+### Modify displayimagetask
 
-Change the `display_image_task` from a `PromptTask` to a `CodeExecutionTask`. We'll then modify the prompt to just take the image name, and also provide the `on_run`. Note, we haven't _created_ the function yet, we'll do that in the next step.
+Change the `displayimagetask` from a `PromptTask` to a `CodeExecutionTask`. We'll then modify the prompt to just take the image name, and also provide the `on_run`. Note, we haven't _created_ the function yet, we'll do that in the next step.
 
 ```python title="app.py" hl_lines="3 4 6"
 # ...
 
-display_image_task = CodeExecutionTask(
+displayimagetask = CodeExecutionTask(
     "{{ parent.output.name }}",
     context={"output_dir": output_dir},
     on_run=display_image,
@@ -144,7 +144,7 @@ display_image_task = CodeExecutionTask(
 
 ## Create Display Image Function
 
-Now we get to create the `display_image` function that the `CodeExecutionTask` will run. You can create this anywhere in your code _before_ you create the `display_image_task`, however, to ensure your code is easy to read I recommend you do it before you instantiate the Pipeline. Before creating it, we'll need to import one more item.
+Now we get to create the `display_image` function that the `CodeExecutionTask` will run. You can create this anywhere in your code _before_ you create the `displayimagetask`, however, to ensure your code is easy to read I recommend you do it before you instantiate the Pipeline. Before creating it, we'll need to import one more item.
 
 ### Import TextArtifact
 


### PR DESCRIPTION


<!-- readthedocs-preview griptape-trade-school start -->
----
📚 Documentation preview 📚: https://griptape-trade-school--149.org.readthedocs.build/en/149/

<!-- readthedocs-preview griptape-trade-school end -->